### PR TITLE
org.webosports.app.calculator: Add requiredPermissions

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -7,6 +7,7 @@
 	"type": "web",
 	"main": "index.html",
 	"icon": "icon.png",
-	"uiRevision": "2"
+	"uiRevision": "2",
+	"requiredPermissions": ["settings"]
 }
 


### PR DESCRIPTION
Add permissions to "settings" in order to read devmode status.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>